### PR TITLE
Remove 'on Open Collective' from fund donate buttons

### DIFF
--- a/app/views/funds/_header.html.erb
+++ b/app/views/funds/_header.html.erb
@@ -14,10 +14,10 @@
         <h1 class="display-1 extra-bold"><%= @fund.name %></h1>
         <p><%= @fund.description %></p>
         <% if @fund.open_collective_project_url.present? %>
-          <%= link_to "Fund the #{@fund.name} Ecosystem on Open Collective", donate_fund_path(@fund), class: 'btn btn-success btn-fund-header-cta dark-shadow rounded-pill mb-3' %>
+          <%= link_to "Fund the #{@fund.name} Ecosystem", donate_fund_path(@fund), class: 'btn btn-success btn-fund-header-cta dark-shadow rounded-pill mb-3' %>
         <% else %>
           <%= form_with url: setup_fund_path(@fund), method: :post, class: 'd-inline' do %>
-            <%= submit_tag "Fund the #{@fund.name} Ecosystem on Open Collective", class: 'btn btn-success btn-fund-header-cta dark-shadow rounded-pill mb-3' %>
+            <%= submit_tag "Fund the #{@fund.name} Ecosystem", class: 'btn btn-success btn-fund-header-cta dark-shadow rounded-pill mb-3' %>
           <% end %>
         <% end %>
 


### PR DESCRIPTION
Tiny change, we now have a donation flow from the ecosystems site itself