### PR TITLE
Serve GitHub Sponsors CSV exports from dated, immutable URLs

### DIFF
--- a/app/controllers/admin/allocations_controller.rb
+++ b/app/controllers/admin/allocations_controller.rb
@@ -2,7 +2,18 @@ class Admin::AllocationsController < Admin::ApplicationController
   skip_before_action :require_basic_auth, only: [:github_sponsors]
   
   def github_sponsors
-    csv_string = Allocation.github_sponsors_csv_export(Allocation.not_completed.all) 
-    send_data csv_string, filename: "github_sponsors.csv", type: "text/csv"
+    if params[:date].blank?
+      redirect_to github_sponsors_dated_admin_allocations_path(date: Date.today.iso8601, format: :csv)
+      return
+    end
+
+    date = begin
+      Date.iso8601(params[:date])
+    rescue Date::Error
+      raise ActiveRecord::RecordNotFound
+    end
+
+    csv_string = Allocation.github_sponsors_csv_export(Allocation.not_completed_as_of(date.end_of_day))
+    send_data csv_string, filename: "github_sponsors-#{date.iso8601}.csv", type: "text/csv"
   end
 end

--- a/app/controllers/admin/allocations_controller.rb
+++ b/app/controllers/admin/allocations_controller.rb
@@ -1,5 +1,5 @@
 class Admin::AllocationsController < Admin::ApplicationController
-  skip_before_action :require_basic_auth, only: [:github_sponsors]
+  skip_before_action :require_basic_auth, only: [:github_sponsors, :github_sponsors_history]
   
   def github_sponsors
     if params[:date].blank?
@@ -15,5 +15,10 @@ class Admin::AllocationsController < Admin::ApplicationController
 
     csv_string = Allocation.github_sponsors_csv_export(Allocation.not_completed_as_of(date.end_of_day))
     send_data csv_string, filename: "github_sponsors-#{date.iso8601}.csv", type: "text/csv"
+  end
+
+  def github_sponsors_history
+    csv_string = Allocation.github_sponsors_csv_export_history
+    send_data csv_string, filename: "github_sponsors_history.csv", type: "text/csv"
   end
 end

--- a/app/mailers/allocation_mailer.rb
+++ b/app/mailers/allocation_mailer.rb
@@ -1,6 +1,6 @@
 class AllocationMailer < ApplicationMailer
   def github_sponsors_csv(recipient)
-    @url = 'https://funds.ecosyste.ms/admin/allocations/github_sponsors.csv'
+    @url = "https://funds.ecosyste.ms/admin/allocations/github_sponsors/#{Date.today.iso8601}.csv"
     mail(to: recipient, subject: 'Ecosyste.ms Funds GitHub Sponsors Bulk CSV Export')
   end
 end

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -7,6 +7,7 @@ class Allocation < ApplicationRecord
   scope :displayable, -> { where('funded_projects_count > 0') }
   scope :completed, -> { where.not(completed_at: nil) }
   scope :not_completed, -> { where(completed_at: nil) }
+  scope :not_completed_as_of, ->(time) { where(created_at: ..time).where('completed_at IS NULL OR completed_at > ?', time) }
 
   validates_uniqueness_of :slug, scope: :fund_id
 

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -343,6 +343,7 @@ class Allocation < ApplicationRecord
     project_allocations.includes(:funding_source).select{|pa| pa.funding_source.blank?}.length
   end
 
+  # GitHub Sponsors bulk uploads only accept whole dollar amounts
   def github_sponsors_csv_export
     CSV.generate do |csv|
       csv << ['Maintainer username', 'Sponsorship amount in USD']
@@ -355,7 +356,7 @@ class Allocation < ApplicationRecord
         .sort_by { |_, amount_cents| -amount_cents }
 
       grouped_allocations.each do |(maintainer, _), amount_cents|
-        csv << [maintainer, amount_cents / 100.0]
+        csv << [maintainer, amount_cents / 100]
       end
     end
   end
@@ -368,19 +369,46 @@ class Allocation < ApplicationRecord
     allocations.flat_map(&:project_allocations).select { |pa| pa.funding_source&.platform == 'github.com' }.sum(&:amount_cents)
   end
 
+  def self.github_sponsors_grouped_allocations(allocations)
+    allocations.flat_map(&:project_allocations)
+      .select { |pa| pa.funding_source&.platform == 'github.com' }
+      .group_by { |pa| [pa.funding_source.name, pa.funding_source] }
+      .transform_values { |pas| pas.sum(&:amount_cents) }
+      .select { |(_, fs), amount_cents| amount_cents >= fs.minimum_donation_ammount_cents }
+      .sort_by { |_, amount_cents| -amount_cents }
+  end
+
+  # GitHub Sponsors bulk uploads only accept whole dollar amounts
   def self.github_sponsors_csv_export(allocations)
     CSV.generate do |csv|
       csv << ['Maintainer username', 'Sponsorship amount in USD']
 
-      grouped_allocations = allocations.flat_map(&:project_allocations)
-        .select { |pa| pa.funding_source&.platform == 'github.com' }
-        .group_by { |pa| [pa.funding_source.name, pa.funding_source] }
-        .transform_values { |pas| pas.sum(&:amount_cents) }
-        .select { |(_, fs), amount_cents| amount_cents >= fs.minimum_donation_ammount_cents }
-        .sort_by { |_, amount_cents| -amount_cents }
-
-      grouped_allocations.each do |(maintainer, _), amount_cents|
+      github_sponsors_grouped_allocations(allocations).each do |(maintainer, _), amount_cents|
         csv << [maintainer, amount_cents / 100]
+      end
+    end
+  end
+
+  GITHUB_SPONSORS_EXPORT_START = Date.new(2025, 5, 15)
+
+  def self.github_sponsors_export_dates
+    dates = []
+    date = GITHUB_SPONSORS_EXPORT_START
+    while date <= Date.today
+      dates << date
+      date = date >> 1
+    end
+    dates
+  end
+
+  def self.github_sponsors_csv_export_history
+    CSV.generate do |csv|
+      csv << ['Export date', 'Maintainer username', 'Sponsorship amount in USD']
+
+      github_sponsors_export_dates.each do |date|
+        github_sponsors_grouped_allocations(not_completed_as_of(date.end_of_day)).each do |(maintainer, _), amount_cents|
+          csv << [date.iso8601, maintainer, amount_cents / 100]
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     resources :allocations, only: [:index] do
       collection do
         get :github_sponsors
+        get 'github_sponsors/:date', action: :github_sponsors, as: :github_sponsors_dated, constraints: { date: /\d{4}-\d{2}-\d{2}/ }
       end
     end
     resources :events, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     resources :allocations, only: [:index] do
       collection do
         get :github_sponsors
+        get :github_sponsors_history
         get 'github_sponsors/:date', action: :github_sponsors, as: :github_sponsors_dated, constraints: { date: /\d{4}-\d{2}-\d{2}/ }
       end
     end

--- a/test/controllers/admin/allocations_controller_test.rb
+++ b/test/controllers/admin/allocations_controller_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class Admin::AllocationsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @fund = create(:fund)
+    @funding_source = create(:funding_source, url: 'https://github.com/sponsors/dtolnay', platform: 'github.com', github_sponsors: {})
+    @allocation = create(:allocation, fund: @fund, created_at: Time.utc(2025, 5, 1))
+    @project = create(:project)
+    create(:project_allocation, allocation: @allocation, project: @project, fund: @fund, funding_source: @funding_source, amount_cents: 5000)
+  end
+
+  test "github_sponsors without date redirects to today's dated export" do
+    get github_sponsors_admin_allocations_url(format: :csv)
+    assert_redirected_to github_sponsors_dated_admin_allocations_url(date: Date.today.iso8601, format: :csv)
+  end
+
+  test "dated github_sponsors includes allocations not completed on that date" do
+    get github_sponsors_dated_admin_allocations_url(date: '2025-05-15', format: :csv)
+    assert_response :success
+    assert_match 'dtolnay', response.body
+    assert_match 'github_sponsors-2025-05-15.csv', response.headers['Content-Disposition']
+  end
+
+  test "dated github_sponsors excludes allocations completed before that date" do
+    @allocation.update!(completed_at: Time.utc(2025, 5, 28))
+    get github_sponsors_dated_admin_allocations_url(date: '2025-06-15', format: :csv)
+    assert_response :success
+    refute_match 'dtolnay', response.body
+  end
+
+  test "dated github_sponsors excludes allocations created after that date" do
+    get github_sponsors_dated_admin_allocations_url(date: '2025-04-15', format: :csv)
+    assert_response :success
+    refute_match 'dtolnay', response.body
+  end
+
+  test "dated github_sponsors returns 404 for invalid date" do
+    get github_sponsors_dated_admin_allocations_url(date: '2025-99-99', format: :csv)
+    assert_response :not_found
+  end
+end

--- a/test/controllers/admin/allocations_controller_test.rb
+++ b/test/controllers/admin/allocations_controller_test.rb
@@ -34,6 +34,17 @@ class Admin::AllocationsControllerTest < ActionDispatch::IntegrationTest
     refute_match 'dtolnay', response.body
   end
 
+  test "github_sponsors_history returns combined csv with a date column" do
+    @allocation.update!(completed_at: Time.utc(2025, 5, 28))
+
+    get github_sponsors_history_admin_allocations_url(format: :csv)
+    assert_response :success
+    assert_match 'Export date,Maintainer username,Sponsorship amount in USD', response.body
+    assert_match '2025-05-15,dtolnay,50', response.body
+    refute_match '2025-06-15', response.body
+    assert_match 'github_sponsors_history.csv', response.headers['Content-Disposition']
+  end
+
   test "dated github_sponsors returns 404 for invalid date" do
     get github_sponsors_dated_admin_allocations_url(date: '2025-99-99', format: :csv)
     assert_response :not_found

--- a/test/mailers/allocation_mailer_test.rb
+++ b/test/mailers/allocation_mailer_test.rb
@@ -10,6 +10,6 @@ class AllocationMailerTest < ActionMailer::TestCase
 
     assert_equal ["test@example.com"], email.to
     assert_equal "Ecosyste.ms Funds GitHub Sponsors Bulk CSV Export", email.subject
-    assert_match "https://funds.ecosyste.ms/admin/allocations/github_sponsors.csv", email.body.to_s
+    assert_match "https://funds.ecosyste.ms/admin/allocations/github_sponsors/#{Date.today.iso8601}.csv", email.body.to_s
   end
 end

--- a/test/models/allocation_test.rb
+++ b/test/models/allocation_test.rb
@@ -231,6 +231,31 @@ class AllocationTest < ActiveSupport::TestCase
     assert_includes june_snapshot, lingering
   end
 
+  test 'github_sponsors_csv_export_history includes rows per export date with fractional dollars' do
+    fs = FundingSource.create!(url: 'https://github.com/sponsors/dtolnay', platform: 'github.com', github_sponsors: {})
+    project = Project.create!(url: 'https://github.com/dtolnay/serde', licenses: ['mit'], registry_names: ['npm'], repository: { 'archived' => false }, funding_source: fs)
+
+    may = Allocation.create!(fund_id: @fund.id, year: 2025, month: 5, total_cents: 1000, created_at: Time.utc(2025, 5, 1), completed_at: Time.utc(2025, 5, 28))
+    ProjectAllocation.create!(allocation: may, project: project, fund: @fund, funding_source: fs, amount_cents: 7050, score: 0.5)
+
+    csv = Allocation.github_sponsors_csv_export_history
+    lines = csv.lines.map(&:strip)
+
+    assert_equal 'Export date,Maintainer username,Sponsorship amount in USD', lines.first
+    assert_includes lines, '2025-05-15,dtolnay,70'
+    refute lines.any? { |l| l.start_with?('2025-06-15') }, "Expected no rows after allocation completed"
+  end
+
+  test 'github_sponsors_csv_export rounds down to whole dollars for github bulk upload' do
+    fs = FundingSource.create!(url: 'https://github.com/sponsors/dtolnay', platform: 'github.com', github_sponsors: {})
+    project = Project.create!(url: 'https://github.com/dtolnay/serde', licenses: ['mit'], registry_names: ['npm'], repository: { 'archived' => false }, funding_source: fs)
+    ProjectAllocation.create!(allocation: @allocation, project: project, fund: @fund, funding_source: fs, amount_cents: 7050, score: 0.5)
+
+    csv = Allocation.github_sponsors_csv_export([@allocation])
+
+    assert_includes csv, "dtolnay,70\n"
+  end
+
   test 'payout_proxy_collectives groups allocations by funding source' do
     funding_source = FundingSource.create!(
       url: 'https://github.com/sponsors/testuser',

--- a/test/models/allocation_test.rb
+++ b/test/models/allocation_test.rb
@@ -215,6 +215,22 @@ class AllocationTest < ActiveSupport::TestCase
     refute lines.any? { |l| l.include?('cowtowncoder') }, "Expected cowtowncoder excluded from CSV (below minimum)"
   end
 
+  test 'not_completed_as_of returns allocations pending at the given time' do
+    may = Allocation.create!(fund_id: @fund.id, year: 2025, month: 5, total_cents: 1000, created_at: Time.utc(2025, 5, 1), completed_at: Time.utc(2025, 5, 28))
+    june = Allocation.create!(fund_id: @fund.id, year: 2025, month: 6, total_cents: 1000, created_at: Time.utc(2025, 6, 1), completed_at: Time.utc(2025, 6, 28))
+    lingering = Allocation.create!(fund_id: @fund.id, year: 2025, month: 4, total_cents: 1000, created_at: Time.utc(2025, 4, 1))
+
+    may_snapshot = Allocation.not_completed_as_of(Time.utc(2025, 5, 15, 12))
+    assert_includes may_snapshot, may
+    assert_includes may_snapshot, lingering
+    refute_includes may_snapshot, june
+
+    june_snapshot = Allocation.not_completed_as_of(Time.utc(2025, 6, 15, 12))
+    refute_includes june_snapshot, may
+    assert_includes june_snapshot, june
+    assert_includes june_snapshot, lingering
+  end
+
   test 'payout_proxy_collectives groups allocations by funding source' do
     funding_source = FundingSource.create!(
       url: 'https://github.com/sponsors/testuser',


### PR DESCRIPTION
The monthly payout email always linked to the same undated URL, `/admin/allocations/github_sponsors.csv`, which generates the CSV live from currently not-completed allocations. Every email pointed at the same mutating file, and clicking after `complete_allocations` runs on the 28th returned the wrong month entirely. Historical exports were unrecoverable, which broke reconciliation against GitHub Sponsors' records.

This adds `Allocation.not_completed_as_of(time)` to reconstruct which allocations were pending at any point from `created_at`/`completed_at`, and serves the export from `/admin/allocations/github_sponsors/:date.csv`. Each historical payout run since 2025-05-15 can now be re-fetched, e.g. `github_sponsors/2025-05-15.csv`. The undated URL redirects to today's dated URL so links in old emails keep working, and the email now links to the dated URL for the day it's sent.

Also:

- `/admin/allocations/github_sponsors_history.csv` returns every monthly export since payouts began as one CSV with an `Export date` column, for reconciling the whole history in one file.
- All GitHub Sponsors exports now use whole dollar amounts, since GitHub Sponsors bulk uploads only accept whole dollars. The bulk export already did this; the per-allocation export now matches, and the reason is documented in the code.

Caveat: reconstructed exports use current funding source names and minimum-sponsorship filters, so an account renamed since the original export will differ.