### PR TITLE
Redirect empty fund search to all funds page

### DIFF
--- a/app/controllers/funds_controller.rb
+++ b/app/controllers/funds_controller.rb
@@ -10,6 +10,7 @@ class FundsController < ApplicationController
   end
   
   def search
+    return redirect_to all_funds_path if params[:query].blank?
     @funds = Fund.search(params[:query])
     @pagy, @funds = pagy(@funds)
   end

--- a/test/controllers/funds_controller_test.rb
+++ b/test/controllers/funds_controller_test.rb
@@ -31,6 +31,14 @@ class FundsControllerTest < ActionDispatch::IntegrationTest
     assert_not_includes assigns(:funds), fund2, "Expected fund2 to NOT be in @funds"
   end
 
+  test "search redirects to all funds when query is blank" do
+    get search_funds_url, params: { query: '' }
+    assert_redirected_to all_funds_path
+
+    get search_funds_url
+    assert_redirected_to all_funds_path
+  end
+
   test "search handles hostile query strings" do
     get search_funds_url, params: { query: "') THEN 0 ELSE (SELECT 1) END --" }
     assert_response :success


### PR DESCRIPTION
Submitting the search form with no query currently renders a page with just "Searching N funds" and no results. Redirect blank queries to `/funds/all` instead so users see the full list.

Fixes #677