### PR TITLE
Add missing bin/docker-start script

### DIFF
--- a/bin/docker-start
+++ b/bin/docker-start
@@ -1,0 +1,15 @@
+
+#!/bin/sh
+set -e
+
+# db_host=${DATABASE_HOST:-database.service.funds.internal}
+# while ! nc -z $db_host ${DATABASE_PORT:-5432}; do
+#   echo "Waiting for database to be available..."
+#   sleep 1
+# done
+
+bundle exec rake db:create db:migrate
+rm -rf tmp/pids
+
+# exec foreman start -d .
+exec bundle exec rails s -b 0.0.0.0


### PR DESCRIPTION
The Dockerfile `CMD` references `bin/docker-start` which was never added to this repo, so `docker compose up` fails immediately. Added the same script used across the other ecosyste.ms apps.

Fixes #682