### PR TITLE
Add rswag scaffolding

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::ApplicationController < ApplicationController
+  after_action { pagy_headers_merge(@pagy) if @pagy }
+end

--- a/config/initializers/rswag-ui.rb
+++ b/config/initializers/rswag-ui.rb
@@ -1,0 +1,14 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the swagger-ui
+  # The first parameter is the path (absolute or relative to the UI host) to the corresponding
+  # endpoint and the second is a title that will be displayed in the document selector
+  # NOTE: If you're using rspec-api to expose Swagger files (under openapi_root) as JSON or YAML endpoints,
+  # then the list below should correspond to the relative paths for those endpoints
+
+  c.openapi_endpoint '/docs/api/v1/openapi.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.openapi_root = Rails.root.to_s + '/openapi'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.openapi_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,15 @@ Sidekiq::Web.use Rack::Auth::Basic do |username, password|
 end if Rails.env.production?
 
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/docs'
+  mount Rswag::Api::Engine => '/docs'
   mount Sidekiq::Web => "/sidekiq"
   mount PgHero::Engine, at: "pghero"
+
+  namespace :api do
+    namespace :v1 do
+    end
+  end
 
   namespace :admin do
     resources :invitations, only: [:index]

--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.1
+info:
+  title: "Ecosyste.ms: Funds"
+  description: "An open API service providing funding and allocation information for open source software ecosystems."
+  contact:
+    name: Ecosyste.ms
+    email: support@ecosyste.ms
+    url: https://ecosyste.ms
+  version: 1.0.0
+  license:
+    name: CC-BY-SA-4.0
+    url: https://creativecommons.org/licenses/by-sa/4.0/
+externalDocs:
+  description: GitHub Repository
+  url: https://github.com/ecosyste-ms/funds
+servers:
+- url: https://funds.ecosyste.ms/api/v1
+paths: {}


### PR DESCRIPTION
Wires up rswag to match the other ecosyste.ms apps so #681 can build on it.

- Mounts `Rswag::Ui` and `Rswag::Api` at `/docs`
- Initializers pointing `openapi_root` at `./openapi`
- Stub `openapi/api/v1/openapi.yaml`
- `Api::V1::ApplicationController` base class with pagy headers
- Empty `api/v1` routes namespace

Related #674, #678.