### PR TITLE
Optimize fund show queries

### DIFF
--- a/app/controllers/funds_controller.rb
+++ b/app/controllers/funds_controller.rb
@@ -19,14 +19,10 @@ class FundsController < ApplicationController
     @fund = Fund.find_by!(slug: params[:id])
     raise ActiveRecord::RecordNotFound unless @fund
 
-    @allocation = @fund.allocations.order('created_at DESC').first
+    @allocation = @fund.latest_allocation
     if @allocation
-      @projects = @fund.funded_projects
-        .joins(:project_allocations)
-        .select('projects.*, SUM(project_allocations.amount_cents) AS total_amount_cents')
-        .group('projects.id')
-
-      @projects = Project.from(@projects, :projects).order('total_amount_cents DESC').includes(:project_allocations).limit(5)
+      @projects = @fund.top_funded_projects
+      @allocations = @fund.allocations_with_totals
       @project_allocations = @allocation.project_allocations.includes(:funding_source, :invitation)
                                                              .order('amount_cents desc, score desc')
                                                              .where('amount_cents >= 1')

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -248,7 +248,15 @@ class Allocation < ApplicationRecord
   end
 
   def total_allocated_cents
+    return self[:total_allocated_cents] if has_attribute?(:total_allocated_cents)
+
     project_allocations.sum(:amount_cents)
+  end
+
+  def projects_count
+    return self[:projects_count] if has_attribute?(:projects_count)
+
+    projects.count
   end
 
   def funders_count

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -718,11 +718,11 @@ class Fund < ApplicationRecord
   end
 
   def top_funded_projects
-    funded_project_ids = project_allocations.funding_not_rejected.paid.select(:project_id)
+    funded_project_ids_query = project_allocations.funding_not_rejected.paid.select(:project_id)
     project_allocations_table = ProjectAllocation.arel_table
     total_amount = project_allocations_table[:amount_cents].sum
     ranked_projects = ProjectAllocation
-      .where(project_id: funded_project_ids)
+      .where(project_id: funded_project_ids_query)
       .select(project_allocations_table[:project_id], total_amount.as('total_amount_cents'))
       .group(project_allocations_table[:project_id])
       .order(total_amount.desc)
@@ -783,7 +783,9 @@ class Fund < ApplicationRecord
   end
 
   def latest_allocation
-    @latest_allocation ||= allocations.order(created_at: :desc).first
+    return @latest_allocation if defined?(@latest_allocation)
+
+    @latest_allocation = allocations.order(created_at: :desc).first
   end
 
   def allocations_with_totals

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -717,6 +717,31 @@ class Fund < ApplicationRecord
     funded_project_ids.length
   end
 
+  def top_funded_projects
+    funded_project_ids = project_allocations.funding_not_rejected.paid.select(:project_id)
+    project_allocations_table = ProjectAllocation.arel_table
+    total_amount = project_allocations_table[:amount_cents].sum
+    ranked_projects = ProjectAllocation
+      .where(project_id: funded_project_ids)
+      .select(project_allocations_table[:project_id], total_amount.as('total_amount_cents'))
+      .group(project_allocations_table[:project_id])
+      .order(total_amount.desc)
+      .limit(5)
+
+    projects_table = Project.arel_table
+    funded_project_totals = Arel::Table.new(:funded_project_totals)
+    funded_project_totals_join = projects_table
+      .join(funded_project_totals)
+      .on(funded_project_totals[:project_id].eq(projects_table[:id]))
+      .join_sources
+
+    Project
+      .with(funded_project_totals: ranked_projects)
+      .joins(funded_project_totals_join)
+      .select(projects_table[Arel.star], funded_project_totals[:total_amount_cents])
+      .order(funded_project_totals[:total_amount_cents].desc)
+  end
+
   def funded_project_downloads
     funded_projects.sum(:total_downloads)
   end
@@ -730,19 +755,54 @@ class Fund < ApplicationRecord
   end
 
   def possible_project_downloads
-    possible_projects.sum(:total_downloads)
+    possible_project_totals[0]
   end
 
   def possible_project_dependent_repos
-    possible_projects.sum(:total_dependent_repos)
+    possible_project_totals[1]
   end
 
   def possible_project_dependent_packages
-    possible_projects.sum(:total_dependent_packages)
+    possible_project_totals[2]
+  end
+
+  def possible_project_totals
+    projects_table = Project.arel_table
+    total_for = lambda do |column|
+      Arel::Nodes::NamedFunction.new(
+        'COALESCE',
+        [projects_table[column].sum, Arel::Nodes.build_quoted(0)]
+      )
+    end
+
+    @possible_project_totals ||= possible_projects.pick(
+      total_for.call(:total_downloads),
+      total_for.call(:total_dependent_repos),
+      total_for.call(:total_dependent_packages)
+    )
   end
 
   def latest_allocation
-    allocations.order(created_at: :desc).first
+    @latest_allocation ||= allocations.order(created_at: :desc).first
+  end
+
+  def allocations_with_totals
+    allocations_table = Allocation.arel_table
+    project_allocations_table = ProjectAllocation.arel_table
+    total_allocated = Arel::Nodes::NamedFunction.new(
+      'COALESCE',
+      [project_allocations_table[:amount_cents].sum, Arel::Nodes.build_quoted(0)]
+    ).as('total_allocated_cents')
+
+    allocations
+      .left_joins(:project_allocations)
+      .select(
+        allocations_table[Arel.star],
+        total_allocated,
+        project_allocations_table[:id].count.as('projects_count')
+      )
+      .group(allocations_table[:id])
+      .order(created_at: :desc)
   end
 
   def completed_allocations_total

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -842,6 +842,6 @@ class Project < ApplicationRecord
   def total_allocated
     return self[:total_amount_cents] if has_attribute?(:total_amount_cents)
 
-    project_allocations.sum(&:amount_cents)
+    project_allocations.sum(:amount_cents)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -840,6 +840,8 @@ class Project < ApplicationRecord
   end
 
   def total_allocated
+    return self[:total_amount_cents] if has_attribute?(:total_amount_cents)
+
     project_allocations.sum(&:amount_cents)
   end
 end

--- a/app/views/funds/show.html.erb
+++ b/app/views/funds/show.html.erb
@@ -192,10 +192,9 @@
                     </tr>
                   </thead>
                   <tbody>
-                    <% allocations = @fund.allocations.order('created_at desc') %>
-                    <% allocations.each_with_index do |allocation, index| %>
+                    <% @allocations.each_with_index do |allocation, index| %>
                       <tr class="">
-                        <td><%= allocations.length - index %></td>
+                        <td><%= @allocations.length - index %></td>
                         <td><%= link_to number_to_currency((allocation.total_allocated_cents/100.0).round(2)), fund_allocation_path(allocation.fund, allocation) %></td>
                         <td>
                         <% if allocation.completed_at %>
@@ -204,7 +203,7 @@
                           In progress
                           <% end %>
                         </td>
-                        <td><%= allocation.projects.count %></td>
+                        <td><%= allocation.projects_count %></td>
                       </tr>
                     <% end %>
                   </tbody>
@@ -255,4 +254,3 @@
       </small>
     </p>
 </div>
-

--- a/db/migrate/20260810120000_add_index_to_projects_registry_names.rb
+++ b/db/migrate/20260810120000_add_index_to_projects_registry_names.rb
@@ -1,0 +1,7 @@
+class AddIndexToProjectsRegistryNames < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :projects, :registry_names, using: :gin, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_151402) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -147,6 +147,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_151402) do
     t.datetime "updated_at", null: false
     t.citext "url"
     t.index ["funding_source_id"], name: "index_projects_on_funding_source_id"
+    t.index ["registry_names"], name: "index_projects_on_registry_names", using: :gin
     t.index ["url"], name: "index_projects_on_url", unique: true
   end
 

--- a/test/controllers/funds_controller_test.rb
+++ b/test/controllers/funds_controller_test.rb
@@ -13,6 +13,21 @@ class FundsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show does not query allocation totals and project counts per allocation" do
+    fund = create(:fund, primary_topic: nil, registry_name: 'npm')
+    project = create(:project, registry_names: ['npm'], total_downloads: 1)
+    january = create(:allocation, fund: fund, year: 2026, month: 1, funded_projects_count: 1)
+    february = create(:allocation, fund: fund, year: 2026, month: 2, funded_projects_count: 1)
+    create(:project_allocation, fund: fund, allocation: january, project: project, amount_cents: 100, paid_at: Time.current)
+    create(:project_allocation, fund: fund, allocation: february, project: project, amount_cents: 200, paid_at: Time.current)
+
+    queries = record_select_queries { get fund_url(fund) }
+
+    assert_response :success
+    assert_not queries.any? { |sql| sql.match?(/SELECT SUM\(.+\) FROM "project_allocations" WHERE "project_allocations"\."allocation_id"/) }
+    assert_not queries.any? { |sql| sql.match?(/SELECT COUNT\(\*\) FROM "projects".+"project_allocations"\."allocation_id"/) }
+  end
+
   test "should get show with no allocation" do
     fund = Fund.create!(name: 'Test Fund', slug: 'test', 'registry_name': 'npm')
     get fund_url(fund)

--- a/test/models/fund_test.rb
+++ b/test/models/fund_test.rb
@@ -11,6 +11,80 @@ class FundTest < ActiveSupport::TestCase
     assert_equal 3, fund.possible_projects.count
   end
 
+  test 'possible project totals are calculated in one query' do
+    fund = create(:fund, primary_topic: nil, registry_name: 'npm')
+    create(:project, registry_names: ['npm'], total_downloads: 10, total_dependent_repos: 20, total_dependent_packages: 30)
+    create(:project, registry_names: ['npm'], total_downloads: 1, total_dependent_repos: 2, total_dependent_packages: 3)
+    create(:project, registry_names: ['npm'], funding_rejected: true, total_downloads: 100, total_dependent_repos: 100, total_dependent_packages: 100)
+    create(:project, registry_names: ['other'], total_downloads: 100, total_dependent_repos: 100, total_dependent_packages: 100)
+
+    queries = record_select_queries do
+      assert_equal 11, fund.possible_project_downloads
+      assert_equal 22, fund.possible_project_dependent_repos
+      assert_equal 33, fund.possible_project_dependent_packages
+      assert_equal 11, fund.possible_project_downloads
+    end
+
+    aggregate_queries = queries.select { |sql| sql.include?('SUM("projects"."total_downloads")') }
+    assert_equal 1, aggregate_queries.length
+  end
+
+  test 'top funded projects are ranked without loading project allocations' do
+    fund = create(:fund)
+    other_fund = create(:fund)
+    allocation = create(:allocation, fund: fund)
+    other_allocation = create(:allocation, fund: other_fund)
+    first_project = create(:project)
+    second_project = create(:project)
+    unpaid_project = create(:project)
+    rejected_project = create(:project, funding_rejected: true)
+
+    create(:project_allocation, fund: fund, allocation: allocation, project: first_project, amount_cents: 100, paid_at: Time.current)
+    create(:project_allocation, fund: other_fund, allocation: other_allocation, project: first_project, amount_cents: 900, paid_at: Time.current)
+    create(:project_allocation, fund: fund, allocation: allocation, project: second_project, amount_cents: 500, paid_at: Time.current)
+    create(:project_allocation, fund: fund, allocation: allocation, project: unpaid_project, amount_cents: 2000, paid_at: nil)
+    create(:project_allocation, fund: fund, allocation: allocation, project: rejected_project, amount_cents: 3000, paid_at: Time.current)
+
+    projects = nil
+    queries = record_select_queries do
+      projects = fund.top_funded_projects.to_a
+      projects.map(&:total_allocated)
+    end
+
+    assert_equal [first_project, second_project], projects
+    assert_equal [1000, 500], projects.map(&:total_allocated)
+    assert_equal 1, queries.length
+  end
+
+  test 'allocations with totals loads every allocation summary in one query' do
+    fund = create(:fund)
+    january = create(:allocation, fund: fund, year: 2026, month: 1, funded_projects_count: 2)
+    february = create(:allocation, fund: fund, year: 2026, month: 2, funded_projects_count: 1)
+    project = create(:project)
+
+    create(:project_allocation, fund: fund, allocation: january, project: project, amount_cents: 100)
+    create(:project_allocation, fund: fund, allocation: january, project: project, amount_cents: 250)
+    create(:project_allocation, fund: fund, allocation: february, project: project, amount_cents: 500)
+
+    allocations = nil
+    queries = record_select_queries do
+      allocations = fund.allocations_with_totals.to_a
+      allocations.map { |allocation| [allocation.total_allocated_cents, allocation.projects_count] }
+    end
+
+    assert_equal [february, january], allocations
+    assert_equal [500, 350], allocations.map(&:total_allocated_cents)
+    assert_equal [1, 2], allocations.map(&:projects_count)
+    assert_equal 1, queries.length
+  end
+
+  test 'registry names has a GIN index' do
+    index = ActiveRecord::Base.connection.indexes(:projects).find { |candidate| candidate.columns == ['registry_names'] }
+
+    assert_not_nil index
+    assert_equal :gin, index.using
+  end
+
   test 'update_stats stores donation totals and donor count from transactions' do
     fund = create(:fund)
     Transaction.create!(fund: fund, uuid: SecureRandom.uuid, transaction_type: 'CREDIT', account: 'alice', amount: 100.0, net_amount: 95.0)

--- a/test/models/fund_test.rb
+++ b/test/models/fund_test.rb
@@ -78,6 +78,17 @@ class FundTest < ActiveSupport::TestCase
     assert_equal 1, queries.length
   end
 
+  test 'latest allocation caches a missing allocation' do
+    fund = create(:fund)
+
+    queries = record_select_queries do
+      assert_nil fund.latest_allocation
+      assert_nil fund.latest_allocation
+    end
+
+    assert_equal 1, queries.length
+  end
+
   test 'registry names has a GIN index' do
     index = ActiveRecord::Base.connection.indexes(:projects).find { |candidate| candidate.columns == ['registry_names'] }
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -1,7 +1,18 @@
 require "test_helper"
 
 class ProjectTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'total allocated uses a database aggregate' do
+    project = create(:project)
+    fund = create(:fund)
+    allocation = create(:allocation, fund: fund)
+    create(:project_allocation, project: project, fund: fund, allocation: allocation, amount_cents: 100)
+    create(:project_allocation, project: project, fund: fund, allocation: allocation, amount_cents: 250)
+
+    queries = record_select_queries do
+      assert_equal 350, project.total_allocated
+    end
+
+    assert_equal 1, queries.length
+    assert_includes queries.first, 'SUM("project_allocations"."amount_cents")'
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,18 @@ Sidekiq::Testing.fake!
 
 class ActiveSupport::TestCase
   include FactoryBot::Syntax::Methods
+
+  def record_select_queries
+    queries = []
+    subscriber = lambda do |_name, _start, _finish, _id, payload|
+      sql = payload[:sql].to_s.lstrip
+      queries << sql if (sql.start_with?('SELECT') || sql.start_with?('WITH')) && !payload[:cached]
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record') { yield }
+    queries
+  end
+
   Shoulda::Matchers.configure do |config|
     config.integrate do |with|
       with.test_framework :minitest


### PR DESCRIPTION
Reduce database time for `FundsController#show` by:

- adding a concurrent GIN index for `projects.registry_names`
- combining possible-project totals into one query
- ranking funded projects with a Rails CTE
- loading allocation totals and project counts in one grouped query

Adds query-count regression coverage for fund show pages.