### PR TITLE
Record skipped allocation months and show round labels on fund page

### DIFF
--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -192,7 +192,7 @@ class Fund < ApplicationRecord
   end
 
   def allocate_to_projects
-    return unless possible_projects.any?
+    return unless possible_projects&.any?
     return if allocations.exists?(year: Time.zone.now.year, month: Time.zone.now.month)
 
     unless has_funds_for_allocation?

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -192,10 +192,26 @@ class Fund < ApplicationRecord
   end
 
   def allocate_to_projects
-    return unless has_funds_for_allocation?
     return unless possible_projects.any?
-    
+    return if allocations.exists?(year: Time.zone.now.year, month: Time.zone.now.month)
+
+    unless has_funds_for_allocation?
+      Rails.logger.info "Fund #{slug}: balance #{current_balance_cents} below minimum #{minimum_for_allocation_cents}, recording skipped allocation"
+      record_skipped_allocation if allocations.completed.exists?
+      return
+    end
+
     allocate(current_balance_cents)
+  end
+
+  def record_skipped_allocation
+    allocations.create!(
+      year: Time.zone.now.year,
+      month: Time.zone.now.month,
+      total_cents: 0,
+      funded_projects_count: 0,
+      completed_at: Time.zone.now
+    )
   end
 
   def has_funds_for_allocation?

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -16,6 +16,8 @@ class Invitation < ApplicationRecord
   def self.delete_expired
     Invitation.draft.not_deleted.find_each do |invitation|
       invitation.delete_expense if invitation.expired?
+    rescue => e
+      Rails.logger.error "Invitation #{invitation.id} delete_expense raised: #{e.class} #{e.message}"
     end
   end
 
@@ -250,9 +252,9 @@ class Invitation < ApplicationRecord
       update!(status: 'DELETED', deleted_at: Time.zone.now)
       log_event('expense_deleted', metadata: { duration_ms: duration_ms })
     end
-  rescue Faraday::Error => e
+  rescue Faraday::Error, JSON::ParserError => e
     log_event('expense_deleted', status: 'error',
-      message: "Network error: #{e.message}",
+      message: "#{e.class}: #{e.message}",
       metadata: { error_class: e.class.name })
   end
 

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -17,7 +17,7 @@ class Invitation < ApplicationRecord
     Invitation.draft.not_deleted.find_each do |invitation|
       invitation.delete_expense if invitation.expired?
     rescue => e
-      Rails.logger.error "Invitation #{invitation.id} delete_expense raised: #{e.class} #{e.message}"
+      Rails.logger.error "Invitation #{invitation.id} delete_expense raised: #{e.class} #{e.message.to_s.truncate(200)}"
     end
   end
 
@@ -254,7 +254,7 @@ class Invitation < ApplicationRecord
     end
   rescue Faraday::Error, JSON::ParserError => e
     log_event('expense_deleted', status: 'error',
-      message: "#{e.class}: #{e.message}",
+      message: "#{e.class}: #{e.message.to_s.truncate(200)}",
       metadata: { error_class: e.class.name })
   end
 

--- a/app/views/funds/show.html.erb
+++ b/app/views/funds/show.html.erb
@@ -199,7 +199,7 @@
                         <td><%= link_to allocation.created_at.strftime('%B %Y'), fund_allocation_path(allocation.fund, allocation) %></td>
                         <td><%= number_to_currency((allocation.total_allocated_cents/100.0).round(2)) %></td>
                         <td>
-                        <% if allocation.funded_projects_count.to_i.zero? && allocation.completed? %>
+                        <% if allocation.total_cents.to_i.zero? && allocation.funded_projects_count.to_i.zero? && allocation.completed? %>
                           Skipped (below minimum)
                         <% elsif allocation.completed_at %>
                           <%= allocation.completed_at.strftime('%B %-d, %Y') %>

--- a/app/views/funds/show.html.erb
+++ b/app/views/funds/show.html.erb
@@ -186,6 +186,7 @@
                   <thead>
                     <tr>
                       <th># <span class="visually-hidden">Number</span></th>
+                      <th>Round</th>
                       <th>Amount</th>
                       <th>Allocated</th>
                       <th>Funded projects</th>
@@ -195,9 +196,12 @@
                     <% @allocations.each_with_index do |allocation, index| %>
                       <tr class="">
                         <td><%= @allocations.length - index %></td>
-                        <td><%= link_to number_to_currency((allocation.total_allocated_cents/100.0).round(2)), fund_allocation_path(allocation.fund, allocation) %></td>
+                        <td><%= link_to allocation.created_at.strftime('%B %Y'), fund_allocation_path(allocation.fund, allocation) %></td>
+                        <td><%= number_to_currency((allocation.total_allocated_cents/100.0).round(2)) %></td>
                         <td>
-                        <% if allocation.completed_at %>
+                        <% if allocation.funded_projects_count.to_i.zero? && allocation.completed? %>
+                          Skipped (below minimum)
+                        <% elsif allocation.completed_at %>
                           <%= allocation.completed_at.strftime('%B %-d, %Y') %>
                           <% else %>
                           In progress

--- a/app/views/funds/show.html.erb
+++ b/app/views/funds/show.html.erb
@@ -202,7 +202,7 @@
                         <% if allocation.total_cents.to_i.zero? && allocation.funded_projects_count.to_i.zero? && allocation.completed? %>
                           Skipped (below minimum)
                         <% elsif allocation.completed_at %>
-                          <%= allocation.completed_at.strftime('%B %-d, %Y') %>
+                          <%= allocation.completed_at.strftime('%d/%m/%Y') %>
                           <% else %>
                           In progress
                           <% end %>

--- a/test/controllers/funds_controller_test.rb
+++ b/test/controllers/funds_controller_test.rb
@@ -13,6 +13,16 @@ class FundsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show displays allocation completion dates in a compact format" do
+    fund = create(:fund, primary_topic: nil, registry_name: 'npm')
+    create(:allocation, fund: fund, completed_at: Time.zone.local(2026, 3, 28))
+
+    get fund_url(fund)
+
+    assert_response :success
+    assert_select "td", text: "28/03/2026"
+  end
+
   test "show does not query allocation totals and project counts per allocation" do
     fund = create(:fund, primary_topic: nil, registry_name: 'npm')
     project = create(:project, registry_names: ['npm'], total_downloads: 1)

--- a/test/models/fund_test.rb
+++ b/test/models/fund_test.rb
@@ -158,4 +158,42 @@ class FundTest < ActiveSupport::TestCase
     assert_equal 7, fund.total_donors
     assert_equal 67.89, fund.completed_allocations_total
   end
+
+  test 'allocate_to_projects records a skipped allocation when balance is below minimum and fund has prior rounds' do
+    fund = create(:fund, primary_topic: nil, registry_name: 'npm')
+    create(:project, registry_names: ['npm'], funding_rejected: false, total_dependent_repos: 1)
+    create(:allocation, fund: fund, year: 2020, month: 1, completed_at: 1.year.ago)
+    create(:transaction, fund: fund, net_amount: 500.0)
+
+    assert_difference -> { fund.allocations.count } do
+      fund.allocate_to_projects
+    end
+
+    skipped = fund.allocations.order(:created_at).last
+    assert_equal 0, skipped.total_cents
+    assert_equal 0, skipped.funded_projects_count
+    assert skipped.completed?
+    assert_equal Time.zone.now.year, skipped.year
+    assert_equal Time.zone.now.month, skipped.month
+  end
+
+  test 'allocate_to_projects does not record a skipped allocation for funds with no prior rounds' do
+    fund = create(:fund, primary_topic: nil, registry_name: 'npm')
+    create(:project, registry_names: ['npm'], funding_rejected: false, total_dependent_repos: 1)
+    create(:transaction, fund: fund, net_amount: 500.0)
+
+    assert_no_difference -> { fund.allocations.count } do
+      fund.allocate_to_projects
+    end
+  end
+
+  test 'allocate_to_projects does nothing when an allocation already exists for the current month' do
+    fund = create(:fund, primary_topic: nil, registry_name: 'npm')
+    create(:project, registry_names: ['npm'], funding_rejected: false, total_dependent_repos: 1)
+    create(:allocation, fund: fund, year: Time.zone.now.year, month: Time.zone.now.month, completed_at: 1.day.ago)
+
+    assert_no_difference -> { fund.allocations.count } do
+      fund.allocate_to_projects
+    end
+  end
 end

--- a/test/models/fund_test.rb
+++ b/test/models/fund_test.rb
@@ -196,4 +196,11 @@ class FundTest < ActiveSupport::TestCase
       fund.allocate_to_projects
     end
   end
+
+  test 'allocate_to_projects returns quietly for funds with no topic or registry' do
+    fund = create(:fund, primary_topic: nil, registry_name: nil)
+
+    assert_nil fund.possible_projects
+    assert_nothing_raised { fund.allocate_to_projects }
+  end
 end

--- a/test/models/fund_test.rb
+++ b/test/models/fund_test.rb
@@ -160,21 +160,23 @@ class FundTest < ActiveSupport::TestCase
   end
 
   test 'allocate_to_projects records a skipped allocation when balance is below minimum and fund has prior rounds' do
-    fund = create(:fund, primary_topic: nil, registry_name: 'npm')
-    create(:project, registry_names: ['npm'], funding_rejected: false, total_dependent_repos: 1)
-    create(:allocation, fund: fund, year: 2020, month: 1, completed_at: 1.year.ago)
-    create(:transaction, fund: fund, net_amount: 500.0)
+    freeze_time do
+      fund = create(:fund, primary_topic: nil, registry_name: 'npm')
+      create(:project, registry_names: ['npm'], funding_rejected: false, total_dependent_repos: 1)
+      create(:allocation, fund: fund, year: 2020, month: 1, completed_at: 1.year.ago)
+      create(:transaction, fund: fund, net_amount: 500.0)
 
-    assert_difference -> { fund.allocations.count } do
-      fund.allocate_to_projects
+      assert_difference -> { fund.allocations.count } do
+        fund.allocate_to_projects
+      end
+
+      skipped = fund.allocations.order(:id).last
+      assert_equal 0, skipped.total_cents
+      assert_equal 0, skipped.funded_projects_count
+      assert skipped.completed?
+      assert_equal Time.zone.now.year, skipped.year
+      assert_equal Time.zone.now.month, skipped.month
     end
-
-    skipped = fund.allocations.order(:created_at).last
-    assert_equal 0, skipped.total_cents
-    assert_equal 0, skipped.funded_projects_count
-    assert skipped.completed?
-    assert_equal Time.zone.now.year, skipped.year
-    assert_equal Time.zone.now.month, skipped.month
   end
 
   test 'allocate_to_projects does not record a skipped allocation for funds with no prior rounds' do

--- a/test/models/invitation_test.rb
+++ b/test/models/invitation_test.rb
@@ -30,4 +30,26 @@ class InvitationTest < ActiveSupport::TestCase
 
     assert_equal "unique_token", invitation2.token
   end
+
+  test "delete_expired continues past an invitation whose delete_expense raises" do
+    create(:invitation, status: 'DRAFT')
+    create(:invitation, status: 'DRAFT')
+
+    Invitation.any_instance.stubs(:expired?).returns(true)
+    Invitation.any_instance.expects(:delete_expense).twice.raises(JSON::ParserError, 'boom')
+
+    assert_nothing_raised { Invitation.delete_expired }
+  end
+
+  test "delete_expense logs an error event when the response body is not JSON" do
+    invitation = create(:invitation, data: { 'id' => 'ex_1', 'status' => 'DRAFT' })
+    stub_request(:post, /graphql/).to_return(body: '<html>502</html>')
+
+    assert_nothing_raised { invitation.delete_expense }
+
+    assert_nil invitation.reload.deleted_at
+    event = ProjectAllocationEvent.where(invitation: invitation, event_type: 'expense_deleted').last
+    assert_equal 'error', event.status
+    assert_equal 'JSON::ParserError', event.metadata['error_class']
+  end
 end


### PR DESCRIPTION
The python fund page showed an "In progress" row directly after the June 28 completed row, which read as a July round stuck for a month. It was actually the August round; July was silently skipped because the balance was $523 (below the $1000 minimum) when `funds:run_allocations` ran on 1 July, and nothing recorded that.

`Fund#allocate_to_projects` now logs when the balance check fails and, for funds that have at least one prior completed round, creates a completed zero-value allocation for the month so the gap is visible in the history. Funds that have never allocated don't accumulate empty rows. The `possible_projects` guard is now nil-safe so a fund with neither `primary_topic` nor `registry_name` can't abort the monthly run.

The allocations table on the fund page gains a Round column (e.g. "August 2026") linking to the allocation, and shows "Skipped (below minimum)" for rows where both `total_cents` and `funded_projects_count` are zero.

Separately, `Invitation.delete_expired` now rescues per-invitation and `delete_expense` handles non-JSON responses from the OC API, so a single bad response on the 28th can't abort `funds:complete_allocations` before it marks open rounds complete. Error messages from these paths are truncated to 200 chars so a large HTML error page doesn't end up in logs or the events table.

To backfill the missing July 2026 row for python after deploy:

```ruby
f = Fund.find_by(slug: 'python'); f.allocations.create!(year: 2026, month: 7, total_cents: 0, funded_projects_count: 0, created_at: Time.utc(2026,7,1,12), completed_at: Time.utc(2026,7,1,12))
```