### PR TITLE
Add Funds Projects API with supporting tests

### DIFF
--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -4,8 +4,8 @@ module Api
   module V1
     class ProjectsController < Api::V1::ApplicationController
       def index
-        slug = params[:slug].to_s.strip
-        return head :bad_request if slug.blank? || slug.length > 100
+        fund_slug = params[:fund_slug].to_s.strip
+        return head :bad_request if fund_slug.blank? || fund_slug.length > 100
 
         page = params[:page].present? ? params[:page].to_i : 1
         return head :bad_request if page < 1 || page > 100_000
@@ -13,7 +13,7 @@ module Api
         limit = params[:limit].present? ? params[:limit].to_i : 20
         return head :bad_request if limit < 1 || limit > 1000
 
-        @fund = Fund.find_by(slug: slug)
+        @fund = Fund.find_by(slug: fund_slug)
         return head :not_found unless @fund
 
         @projects = @fund.funded_projects

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ProjectsController < Api::V1::ApplicationController
+      def index
+        slug = params[:slug].to_s.strip
+        return head :bad_request if slug.blank? || slug.length > 100
+
+        page = params[:page].present? ? params[:page].to_i : 1
+        return head :bad_request if page < 1 || page > 100_000
+
+        limit = params[:limit].present? ? params[:limit].to_i : 20
+        return head :bad_request if limit < 1 || limit > 1000
+
+        @fund = Fund.find_by(slug: slug)
+        return head :not_found unless @fund
+
+        @projects = @fund.funded_projects
+                         .joins(:project_allocations)
+                         .select('projects.*, SUM(project_allocations.amount_cents) AS total_amount_cents')
+                         .group('projects.id')
+
+        @projects = Project.from(@projects, :projects).order('total_amount_cents DESC').includes(:project_allocations)
+
+        @pagy, @projects = pagy(@projects, page: page, limit: limit)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -16,13 +16,7 @@ module Api
         @fund = Fund.find_by(slug: fund_slug)
         return head :not_found unless @fund
 
-        @projects = @fund.funded_projects
-                         .joins(:project_allocations)
-                         .select('projects.*, SUM(project_allocations.amount_cents) AS total_amount_cents')
-                         .group('projects.id')
-
-        @projects = Project.from(@projects, :projects).order('total_amount_cents DESC').includes(:project_allocations)
-
+        @projects = @fund.funded_projects_with_totals
         @pagy, @projects = pagy(@projects, page: page, limit: limit)
       end
     end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -2,13 +2,7 @@ class ProjectsController < ApplicationController
   def index
     @fund = Fund.find_by!(slug: params[:fund_id])
     raise ActiveRecord::RecordNotFound unless @fund
-    @projects = @fund.funded_projects
-        .joins(:project_allocations)
-        .select('projects.*, SUM(project_allocations.amount_cents) AS total_amount_cents')
-        .group('projects.id')
-
-    @projects = Project.from(@projects, :projects).order('total_amount_cents DESC').includes(:project_allocations)
-
+    @projects = @fund.funded_projects_with_totals
     @pagy, @projects = pagy(@projects)
   end
 

--- a/app/models/fund.rb
+++ b/app/models/fund.rb
@@ -827,6 +827,21 @@ class Fund < ApplicationRecord
     completed_allocations_total_cents / 100.0
   end
 
+  def funded_projects_with_totals
+    projects = Project.arel_table
+    allocations = ProjectAllocation.arel_table
+    total = allocations[:amount_cents].sum
+
+    Project
+      .joins(:project_allocations)
+      .where(project_allocations: { fund_id: id })
+      .where.not(project_allocations: { paid_at: nil })
+      .where(projects: { funding_rejected: false })
+      .select(projects[Arel.star], total.as("total_amount_cents"))
+      .group(projects[:id])
+      .order(total.desc)
+  end
+
   def update_stats
     update(
       balance: current_balance,

--- a/app/views/api/v1/projects/index.json.jbuilder
+++ b/app/views/api/v1/projects/index.json.jbuilder
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+json.fund_name @fund.name
+json.projects_count @fund.possible_projects_count
+json.funded_projects_count @fund.funded_projects_count
+json.completed_allocations_total do
+  json.value @fund.completed_allocations_total
+  json.currency 'USD'
+end
+json.current_page @pagy.page
+json.total_pages @pagy.pages
+
+json.projects @projects do |project|
+  json.name project.to_s
+  json.repo_link project.url
+  json.allocated_amount do
+    json.value(project.total_allocated / 100)
+    json.currency 'USD'
+  end
+  json.downloads project.total_downloads
+  json.dependent_repos project.total_dependent_repos
+  json.dependent_packages project.total_dependent_packages
+end

--- a/app/views/api/v1/projects/index.json.jbuilder
+++ b/app/views/api/v1/projects/index.json.jbuilder
@@ -14,7 +14,7 @@ json.projects @projects do |project|
   json.name project.to_s
   json.repo_link project.url
   json.allocated_amount do
-    json.value(project.total_allocated / 100)
+    json.value(project.total_allocated / 100.0)
     json.currency 'USD'
   end
   json.downloads project.total_downloads

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
           get :search
         end
       end
+      get 'funds/:slug/projects', to: 'projects#index', as: :fund_projects
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,14 +12,14 @@ Rails.application.routes.draw do
   mount Sidekiq::Web => "/sidekiq"
   mount PgHero::Engine, at: "pghero"
 
-  namespace :api do
+  namespace :api, :defaults => {:format => :json} do
     namespace :v1 do
       resources :funds, only: [:show], param: :slug do
         collection do
           get :search
         end
+        resources :projects, only: [:index]
       end
-      get 'funds/:slug/projects', to: 'projects#index', as: :fund_projects
     end
   end
 

--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -209,9 +209,9 @@ paths:
                     dependent_repos: 115000
                     dependent_packages: 2660
         "404":
-          description: Fund not found
+          description: Fund with specified slug not found, or slug not specified
         "400":
-          description: Bad request when slug or page number is invalid
+          description: Bad request when invalid page or limit is specified
 
   /funds/{slug}/funders:
     get:

--- a/openapi/api/v1/openapi.yaml
+++ b/openapi/api/v1/openapi.yaml
@@ -144,7 +144,7 @@ paths:
         "404":
           description: Fund not found
 
-  /funds/{slug}/projects:
+  /funds/{fund_slug}/projects:
     get:
       summary: List projects for a fund
       description: >
@@ -154,7 +154,7 @@ paths:
       tags:
         - Projects
       parameters:
-        - name: slug
+        - name: fund_slug
           in: path
           description: Slug of the fund
           example: django

--- a/test/controllers/api/v1/projects_controller_test.rb
+++ b/test/controllers/api/v1/projects_controller_test.rb
@@ -128,7 +128,7 @@ module Api
       end
 
       test 'project index matches openapi spec' do
-        get api_v1_fund_projects_path(slug: 'django'), as: :json
+        get api_v1_fund_projects_path(fund_slug: 'django')
         assert_response :success
 
         json = JSON.parse(response.body)
@@ -161,64 +161,64 @@ module Api
       end
 
       test 'index with empty slug param returns not found' do
-        get api_v1_fund_projects_path(slug: ''), as: :json
+        get api_v1_fund_projects_path(fund_slug: '')
         assert_response :not_found
         assert_empty response.body
       end
 
       test 'index with slug having just whitespaces returns bad request' do
-        get api_v1_fund_projects_path(slug: '     '), as: :json
+        get api_v1_fund_projects_path(fund_slug: '     ')
         assert_response :bad_request
         assert_empty response.body
       end
 
       test 'index with slug not matching a fund returns bad request' do
-        get api_v1_fund_projects_path(slug: 'non-existent-fund'), as: :json
+        get api_v1_fund_projects_path(fund_slug: 'non-existent-fund')
         assert_response :not_found
         assert_empty response.body
       end
 
       test 'index with slug param exceeding 100 characters returns bad request' do
-        get api_v1_fund_projects_path(slug: 'a' * 101), as: :json
+        get api_v1_fund_projects_path(fund_slug: 'a' * 101)
         assert_response :bad_request
         assert_empty response.body
       end
 
       test 'index with invalid page param returns bad request' do
-        get api_v1_fund_projects_path(slug: 'django'), params: { page: 'hello' }, as: :json
+        get api_v1_fund_projects_path(fund_slug: 'django'), params: { page: 'hello' }
         assert_response :bad_request
         assert_empty response.body
 
-        get api_v1_fund_projects_path(slug: 'django'), params: { page: -1 }, as: :json
+        get api_v1_fund_projects_path(fund_slug: 'django'), params: { page: -1 }
         assert_response :bad_request
         assert_empty response.body
 
-        get api_v1_fund_projects_path(slug: 'django'), params: { page: 100_001 }, as: :json
+        get api_v1_fund_projects_path(fund_slug: 'django'), params: { page: 100_001 }
         assert_response :bad_request
         assert_empty response.body
       end
 
       test 'index with invalid limit param returns bad request' do
-        get api_v1_fund_projects_path(slug: 'django'), params: { limit: 'hello' }, as: :json
+        get api_v1_fund_projects_path(fund_slug: 'django'), params: { limit: 'hello' }
         assert_response :bad_request
         assert_empty response.body
 
-        get api_v1_fund_projects_path(slug: 'django'), params: { limit: -1 }, as: :json
+        get api_v1_fund_projects_path(fund_slug: 'django'), params: { limit: -1 }
         assert_response :bad_request
         assert_empty response.body
 
-        get api_v1_fund_projects_path(slug: 'django'), params: { limit: 1001 }, as: :json
+        get api_v1_fund_projects_path(fund_slug: 'django'), params: { limit: 1001 }
         assert_response :bad_request
         assert_empty response.body
       end
 
       test 'index handles hostile query strings' do
-        get api_v1_fund_projects_path(slug: "') THEN 0 ELSE (SELECT 1) END --"), as: :json
+        get api_v1_fund_projects_path(fund_slug: "') THEN 0 ELSE (SELECT 1) END --")
         assert_response :not_found
         assert_empty response.body
       end
 
-      test 'search is paginated with configurable limit of 20 items per page' do
+      test 'index is paginated with configurable limit of 20 items per page' do
         # Allocating 42 new projects
         num_projects = 42
         test_fund = create(:fund, name: 'Test Fund', slug: 'test-fund')
@@ -253,7 +253,7 @@ module Api
         slug = 'test-fund'
 
         # get all 42 items in single page by increasing limit
-        get api_v1_fund_projects_path(slug: slug), params: { page: 1, limit: 50 }, as: :json
+        get api_v1_fund_projects_path(fund_slug: slug), params: { page: 1, limit: 50 }
         assert_response :success
         json = JSON.parse(response.body)
         assert_equal 42, json['projects'].length
@@ -261,7 +261,7 @@ module Api
         assert_equal 1, json['total_pages']
 
         # page 1
-        get api_v1_fund_projects_path(slug: slug), params: { page: 1 }, as: :json
+        get api_v1_fund_projects_path(fund_slug: slug), params: { page: 1 }
         assert_response :success
         json = JSON.parse(response.body)
         assert_equal 20, json['projects'].length
@@ -269,7 +269,7 @@ module Api
         assert_equal 3, json['total_pages']
 
         # page 2 with new limit of 21 per page (page1=22, page2=20)
-        get api_v1_fund_projects_path(slug: slug), params: { page: 2, limit: 22 }, as: :json
+        get api_v1_fund_projects_path(fund_slug: slug), params: { page: 2, limit: 22 }
         assert_response :success
         json = JSON.parse(response.body)
         assert_equal 20, json['projects'].length
@@ -277,12 +277,47 @@ module Api
         assert_equal 2, json['total_pages']
 
         # page 3 for default limit of 20 per page (page1=20, page2=20, page3=2)
-        get api_v1_fund_projects_path(slug: slug), params: { page: 3 }, as: :json
+        get api_v1_fund_projects_path(fund_slug: slug), params: { page: 3 }
         assert_response :success
         json = JSON.parse(response.body)
         assert_equal 2, json['projects'].length
         assert_equal 3, json['current_page']
         assert_equal 3, json['total_pages']
+      end
+
+      test 'index returns project allocated amount converted from cents to dollars' do
+        test_fund = create(:fund, name: 'Test Fund', slug: 'test-fund-cents')
+        test_allocation = create(
+          :allocation,
+          fund: test_fund,
+          year: Time.zone.now.year,
+          month: Time.zone.now.month,
+          total_cents: 1_000_000,
+          funded_projects_count: 1
+        )
+        project = create(
+          :project,
+          registry_names: ['pypi'],
+          keywords: ['python'],
+          funding_rejected: false,
+          total_downloads: 1_000_000,
+          total_dependent_repos: 100,
+          total_dependent_packages: 50
+        )
+        create(
+          :project_allocation,
+          fund: test_fund,
+          allocation: test_allocation,
+          project: project,
+          paid_at: Time.zone.now
+        )
+        test_fund.update_stats
+        Project.any_instance.stubs(:total_allocated).returns(12_345)
+
+        get api_v1_fund_projects_path(fund_slug: 'test-fund-cents')
+        assert_response :success
+        json = JSON.parse(response.body)
+        assert_equal 123.45, json['projects'][0]['allocated_amount']['value']
       end
     end
   end

--- a/test/controllers/api/v1/projects_controller_test.rb
+++ b/test/controllers/api/v1/projects_controller_test.rb
@@ -1,0 +1,289 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Api
+  module V1
+    class ProjectsControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        # a fund Django is created
+        @fund = create(
+          :fund,
+          name: 'Django Fund',
+          description: 'Django is a web application framework for Python.',
+          slug: 'django',
+          primary_topic: 'python',
+          registry_name: 'pypi'
+        )
+
+        # 3 donation transactions to the fund
+        create(
+          :transaction,
+          fund: @fund,
+          legacy_id: '1',
+          uuid: SecureRandom.uuid,
+          amount: 16_875.00,
+          net_amount: 16_875.00,
+          transaction_type: 'CREDIT',
+          transaction_kind: 'DONATION',
+          currency: 'USD',
+          account: 'sentry',
+          account_name: 'Sentry',
+          created_at: Time.zone.now
+        )
+        create(
+          :transaction,
+          fund: @fund,
+          legacy_id: '2',
+          uuid: SecureRandom.uuid,
+          amount: 650.00,
+          net_amount: 650.00,
+          transaction_type: 'CREDIT',
+          transaction_kind: 'DONATION',
+          currency: 'USD',
+          account: 'thibaudcolas',
+          account_name: 'Thibaud Colas',
+          created_at: Time.zone.now
+        )
+        create(
+          :transaction,
+          fund: @fund,
+          legacy_id: '3',
+          uuid: SecureRandom.uuid,
+          amount: 51.00,
+          net_amount: 51.00,
+          transaction_type: 'CREDIT',
+          transaction_kind: 'DONATION',
+          currency: 'USD',
+          account: 'chris-adams',
+          account_name: 'Chris Adams',
+          account_image_url: nil,
+          created_at: Time.zone.now
+        )
+
+        # 2 out of 5 projects in the fund are allocated
+        @project1 = create(
+          :project,
+          name: 'Django',
+          url: 'https://github.com/django/django',
+          licenses: ['bsd'],
+          registry_names: ['pypi'],
+          keywords: ['python'],
+          funding_rejected: false,
+          total_downloads: 542_000_000,
+          total_dependent_repos: 604_000,
+          total_dependent_packages: 8_240
+        )
+        @project2 = create(
+          :project,
+          name: 'Wagtail',
+          url: 'https://github.com/wagtail/wagtail',
+          licenses: ['bsd'],
+          registry_names: ['pypi'],
+          keywords: ['python'],
+          funding_rejected: false,
+          total_downloads: 1_000_000,
+          total_dependent_repos: 100,
+          total_dependent_packages: 50
+        )
+        3.times do
+          create(
+            :project,
+            registry_names: ['pypi'],
+            keywords: ['python'],
+            funding_rejected: false,
+            total_downloads: 1_000_000,
+            total_dependent_repos: 100,
+            total_dependent_packages: 50
+          )
+        end
+        @allocation = create(
+          :allocation,
+          fund: @fund,
+          year: Time.zone.now.year,
+          month: Time.zone.now.month,
+          total_cents: 17_736_00,
+          funded_projects_count: 2
+        )
+        3.times do
+          create(
+            :project_allocation,
+            fund: @fund,
+            allocation: @allocation,
+            project: @project1,
+            paid_at: Time.zone.now
+          )
+        end
+        7.times do
+          create(
+            :project_allocation,
+            fund: @fund,
+            allocation: @allocation,
+            project: @project2,
+            paid_at: Time.zone.now
+          )
+        end
+
+        @fund.update_stats
+      end
+
+      test 'project index matches openapi spec' do
+        get api_v1_fund_projects_path(slug: 'django'), as: :json
+        assert_response :success
+
+        json = JSON.parse(response.body)
+        assert_equal 2, json['projects'].length
+        assert_equal 'Django Fund', json['fund_name']
+        assert json['projects_count'].positive?
+        assert_equal 2, json['funded_projects_count']
+        assert json.key?('completed_allocations_total')
+        assert_equal 1, json['current_page']
+        assert_equal 1, json['total_pages']
+
+        projects = json['projects']
+        wagtail = projects[0]
+        django = projects[1]
+        wagtail_allocated_amt = wagtail['allocated_amount']['value']
+        django_allocated_amount = django['allocated_amount']['value']
+
+        assert_equal 'Wagtail', wagtail['name']
+        assert_equal 'Django', django['name']
+        assert wagtail_allocated_amt.positive?
+        assert django_allocated_amount < wagtail_allocated_amt # to check descending order
+        assert_equal 'https://github.com/wagtail/wagtail', wagtail['repo_link']
+        assert_equal 'https://github.com/django/django', django['repo_link']
+        assert_equal 1_000_000, wagtail['downloads']
+        assert_equal 542_000_000, django['downloads']
+        assert_equal 100, wagtail['dependent_repos']
+        assert_equal 604_000, django['dependent_repos']
+        assert_equal 50, wagtail['dependent_packages']
+        assert_equal 8240, django['dependent_packages']
+      end
+
+      test 'index with empty slug param returns not found' do
+        get api_v1_fund_projects_path(slug: ''), as: :json
+        assert_response :not_found
+        assert_empty response.body
+      end
+
+      test 'index with slug having just whitespaces returns bad request' do
+        get api_v1_fund_projects_path(slug: '     '), as: :json
+        assert_response :bad_request
+        assert_empty response.body
+      end
+
+      test 'index with slug not matching a fund returns bad request' do
+        get api_v1_fund_projects_path(slug: 'non-existent-fund'), as: :json
+        assert_response :not_found
+        assert_empty response.body
+      end
+
+      test 'index with slug param exceeding 100 characters returns bad request' do
+        get api_v1_fund_projects_path(slug: 'a' * 101), as: :json
+        assert_response :bad_request
+        assert_empty response.body
+      end
+
+      test 'index with invalid page param returns bad request' do
+        get api_v1_fund_projects_path(slug: 'django'), params: { page: 'hello' }, as: :json
+        assert_response :bad_request
+        assert_empty response.body
+
+        get api_v1_fund_projects_path(slug: 'django'), params: { page: -1 }, as: :json
+        assert_response :bad_request
+        assert_empty response.body
+
+        get api_v1_fund_projects_path(slug: 'django'), params: { page: 100_001 }, as: :json
+        assert_response :bad_request
+        assert_empty response.body
+      end
+
+      test 'index with invalid limit param returns bad request' do
+        get api_v1_fund_projects_path(slug: 'django'), params: { limit: 'hello' }, as: :json
+        assert_response :bad_request
+        assert_empty response.body
+
+        get api_v1_fund_projects_path(slug: 'django'), params: { limit: -1 }, as: :json
+        assert_response :bad_request
+        assert_empty response.body
+
+        get api_v1_fund_projects_path(slug: 'django'), params: { limit: 1001 }, as: :json
+        assert_response :bad_request
+        assert_empty response.body
+      end
+
+      test 'index handles hostile query strings' do
+        get api_v1_fund_projects_path(slug: "') THEN 0 ELSE (SELECT 1) END --"), as: :json
+        assert_response :not_found
+        assert_empty response.body
+      end
+
+      test 'search is paginated with configurable limit of 20 items per page' do
+        # Allocating 42 new projects
+        num_projects = 42
+        test_fund = create(:fund, name: 'Test Fund', slug: 'test-fund')
+        test_allocation = create(
+          :allocation,
+          fund: test_fund,
+          year: Time.zone.now.year,
+          month: Time.zone.now.month,
+          total_cents: 10_499_00,
+          funded_projects_count: num_projects
+        )
+        num_projects.times do |_i|
+          project = create(
+            :project,
+            registry_names: ['pypi'],
+            keywords: ['python'],
+            funding_rejected: false,
+            total_downloads: 1_000_000,
+            total_dependent_repos: 100,
+            total_dependent_packages: 50
+          )
+          create(
+            :project_allocation,
+            fund: test_fund,
+            allocation: test_allocation,
+            project: project,
+            paid_at: Time.zone.now
+          )
+          test_fund.update_stats
+        end
+
+        slug = 'test-fund'
+
+        # get all 42 items in single page by increasing limit
+        get api_v1_fund_projects_path(slug: slug), params: { page: 1, limit: 50 }, as: :json
+        assert_response :success
+        json = JSON.parse(response.body)
+        assert_equal 42, json['projects'].length
+        assert_equal 1, json['current_page']
+        assert_equal 1, json['total_pages']
+
+        # page 1
+        get api_v1_fund_projects_path(slug: slug), params: { page: 1 }, as: :json
+        assert_response :success
+        json = JSON.parse(response.body)
+        assert_equal 20, json['projects'].length
+        assert_equal 1, json['current_page']
+        assert_equal 3, json['total_pages']
+
+        # page 2 with new limit of 21 per page (page1=22, page2=20)
+        get api_v1_fund_projects_path(slug: slug), params: { page: 2, limit: 22 }, as: :json
+        assert_response :success
+        json = JSON.parse(response.body)
+        assert_equal 20, json['projects'].length
+        assert_equal 2, json['current_page']
+        assert_equal 2, json['total_pages']
+
+        # page 3 for default limit of 20 per page (page1=20, page2=20, page3=2)
+        get api_v1_fund_projects_path(slug: slug), params: { page: 3 }, as: :json
+        assert_response :success
+        json = JSON.parse(response.body)
+        assert_equal 2, json['projects'].length
+        assert_equal 3, json['current_page']
+        assert_equal 3, json['total_pages']
+      end
+    end
+  end
+end

--- a/test/controllers/api/v1/projects_controller_test.rb
+++ b/test/controllers/api/v1/projects_controller_test.rb
@@ -287,12 +287,21 @@ module Api
 
       test 'index returns project allocated amount converted from cents to dollars' do
         test_fund = create(:fund, name: 'Test Fund', slug: 'test-fund-cents')
+        test_fund_2 = create(:fund, name: 'Test Fund 2', slug: 'test-fund-cents-2')
         test_allocation = create(
           :allocation,
           fund: test_fund,
           year: Time.zone.now.year,
           month: Time.zone.now.month,
-          total_cents: 1_000_000,
+          total_cents: 123_45,
+          funded_projects_count: 1
+        )
+        test_allocation_2 = create(
+          :allocation,
+          fund: test_fund_2,
+          year: Time.zone.now.year,
+          month: Time.zone.now.month,
+          total_cents: 678_90,
           funded_projects_count: 1
         )
         project = create(
@@ -309,15 +318,31 @@ module Api
           fund: test_fund,
           allocation: test_allocation,
           project: project,
-          paid_at: Time.zone.now
+          paid_at: Time.zone.now,
+          amount_cents: 123_45
+        )
+        create(
+          :project_allocation,
+          fund: test_fund_2,
+          allocation: test_allocation_2,
+          project: project,
+          paid_at: Time.zone.now,
+          amount_cents: 678_90
         )
         test_fund.update_stats
-        Project.any_instance.stubs(:total_allocated).returns(12_345)
+        test_fund_2.update_stats
 
+        # project funding from test fund 1
         get api_v1_fund_projects_path(fund_slug: 'test-fund-cents')
         assert_response :success
         json = JSON.parse(response.body)
         assert_equal 123.45, json['projects'][0]['allocated_amount']['value']
+
+        # project funding from test fund 2
+        get api_v1_fund_projects_path(fund_slug: 'test-fund-cents-2')
+        assert_response :success
+        json = JSON.parse(response.body)
+        assert_equal 678.90, json['projects'][0]['allocated_amount']['value']
       end
     end
   end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -95,4 +95,66 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select ".card.bg-light", text: /Total Allocated.*\$80\.00/m
   end
+
+  test "should display total allocated amount for specific fund" do
+    test_fund = create(:fund, name: "Test Fund", slug: "test-fund-cents")
+    test_fund_2 = create(:fund, name: "Test Fund 2", slug: "test-fund-cents-2")
+    test_allocation = create(
+      :allocation,
+      fund: test_fund,
+      year: Time.zone.now.year,
+      month: Time.zone.now.month,
+      total_cents: 123_45,
+      funded_projects_count: 1,
+    )
+    test_allocation_2 = create(
+      :allocation,
+      fund: test_fund_2,
+      year: Time.zone.now.year,
+      month: Time.zone.now.month,
+      total_cents: 678_90,
+      funded_projects_count: 1,
+    )
+    project = create(
+      :project,
+      registry_names: ["pypi"],
+      keywords: ["python"],
+      funding_rejected: false,
+      total_downloads: 1_000_000,
+      total_dependent_repos: 100,
+      total_dependent_packages: 50,
+    )
+    create(
+      :project_allocation,
+      fund: test_fund,
+      allocation: test_allocation,
+      project: project,
+      paid_at: Time.zone.now,
+      amount_cents: 123_45,
+    )
+    create(
+      :project_allocation,
+      fund: test_fund_2,
+      allocation: test_allocation_2,
+      project: project,
+      paid_at: Time.zone.now,
+      amount_cents: 678_90,
+    )
+    test_fund.update_stats
+    test_fund_2.update_stats
+
+    # project funding from test 1
+    get fund_projects_path(test_fund)
+    assert_response :success
+    assert_select "tr" do
+      assert_select "td:nth-child(2) a", text: "$123.45"
+    end
+
+    # project funding from test 2
+    get fund_projects_path(test_fund_2)
+    assert_response :success
+    assert_select "tr" do
+      assert_select "td:nth-child(2) a", text: "$678.90"
+    end
+  end
 end


### PR DESCRIPTION
Related to #674.

This PR adds the Funds Projects API (third one [here](https://github.com/ecosyste-ms/funds/issues/674#issuecomment-5054985165)) with supporting tests.